### PR TITLE
make authy config file readable by all

### DIFF
--- a/scripts/authy-vpn-add-user
+++ b/scripts/authy-vpn-add-user
@@ -156,7 +156,7 @@ if [ $? -ne 0 ] ; then
     exit 1
 fi
 chown root $CONFIG_FILE
-chmod 600  $CONFIG_FILE
+chmod 644  $CONFIG_FILE
 
 check_api_key
 register_users


### PR DESCRIPTION
When you have openvpn set to drop permissions it can't read the conf file and fails to auth any user.
There is no particularly sensitive information contained within and having it world readable should not be a problem.

Alternatively, this could be handled at post-install and not reset permission on the file every time a user is added.
