### PR TITLE
readme: follow redirects when downloading tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ __This is the recommended way of installing.__
 
 1. Compile and install.
 
-        curl "https://github.com/authy/authy-openvpn/archive/master.tar.gz" -o authy-openvpn.tar.gz
+        curl -L "https://github.com/authy/authy-openvpn/archive/master.tar.gz" -o authy-openvpn.tar.gz
         tar -zxvf authy-openvpn.tar.gz
         cd authy-openvpn-master
         make


### PR DESCRIPTION
Github responds with a 302 redirect. Tell curl to follow it.

FYI this curl command does not match your website.
