### PR TITLE
fixing issue with usernames in authy-vpn.conf

### DIFF
--- a/src/authy_conf.c
+++ b/src/authy_conf.c
@@ -31,6 +31,10 @@
 #define snprintf _snprintf
 #endif
 
+#ifdef WIN32
+#define strcasecmp _stricmp
+#endif
+
 // Description
 //
 // Checks if pszAuthyId is a valid authyId
@@ -191,7 +195,7 @@ getAuthyIdAndCommonName(__out char **ppszAuthyId,
       pch = strtok (NULL, " \t"); //Go to the next token 
       i++;
     }    
-    if(0 == strcmp(columns[0], pszUsername)){
+    if(0 == strcasecmp(columns[0], pszUsername)){
       trace(DEBUG, __LINE__, "[Authy] Found column for pszUsername=%s column is %s\n", pszUsername, line); 
       break; 
     }


### PR DESCRIPTION
Currently, usernames in authy-vpn.conf are not considered matched unless case matches exactly, leading to a scenario where a configured user could be brute-forced as long as the attacker changes the case in the username, allowing them to potentially bypass Authy authentication (if configured to 'fail open'). This change would check to make sure that the username is matched case-insensitively against authy-vpn.conf, and should work on both POSIX and Windows environments.
