### PR TITLE
Fixed segfault when curl response is 'Token is invalid. Token was used recently.'

### DIFF
--- a/src/authy_api.c
+++ b/src/authy_api.c
@@ -177,7 +177,9 @@ tokenResponseIsValid(char *pszResponse)
      shouldn't be the last one because it won't be a key */
   for (cnt = 0; cnt < 19; cnt++)
   {
-    if(strncmp(pszResponse + (tokens[cnt]).start, "token", (tokens[cnt]).end - (tokens[cnt]).start) == 0)
+    /* avoid matching empty strings since "" == "" */
+    int len = (tokens[cnt]).end - (tokens[cnt]).start;
+    if(len > 0 && strncmp(pszResponse + (tokens[cnt]).start, "token", len) == 0)
     {
       if(strncmp(pszResponse + (tokens[cnt+1]).start, "is valid", (tokens[cnt+1]).end - (tokens[cnt+1]).start) == 0){
         return TRUE;

--- a/src/authy_api.c
+++ b/src/authy_api.c
@@ -170,9 +170,9 @@ tokenResponseIsValid(char *pszResponse)
   int cnt;
   jsmn_parser parser;
   jsmn_init(&parser);
-  jsmntok_t tokens[20];
+  jsmntok_t tokens[20] = {{0}};
   jsmn_parse(&parser, pszResponse, tokens, 20);
-
+  
   /* success isn't always on the same place, look until 19 because it
      shouldn't be the last one because it won't be a key */
   for (cnt = 0; cnt < 19; cnt++)

--- a/src/authy_api.c
+++ b/src/authy_api.c
@@ -172,7 +172,7 @@ tokenResponseIsValid(char *pszResponse)
   jsmn_init(&parser);
   jsmntok_t tokens[20] = {{0}};
   jsmn_parse(&parser, pszResponse, tokens, 20);
-  
+
   /* success isn't always on the same place, look until 19 because it
      shouldn't be the last one because it won't be a key */
   for (cnt = 0; cnt < 19; cnt++)


### PR DESCRIPTION
This server response leads to a segfault (at least on gcc (GCC) 4.2.3 on armv5tel: Synology NAS) on line 180 of authy_api.c:

[Authy] Curl response: Body={"message":"Token is invalid. Token was used recently.","success":false,"errors":{"message":"Token is invalid. Token was used recently."}}

You can easily create this error by using the same client authentication token twice in a row to connect (first is successful, second causes this error).

The reason is that the response contains no "token" key, which means that tokenResponseIsValid reads past the end of the valid tokens into uninitialized memory. By initializing 'tokens' to zero, this causes a number of harmless empty string comparisons. It looks like the newer jsmn_parse (http://zserge.com/jsmn.html) returns the actual number of tokens used, but the one in this repository does not.
