### PR TITLE
Fix --plugin passing init-string as a string argument

### DIFF
--- a/scripts/post-install
+++ b/scripts/post-install
@@ -24,7 +24,7 @@ function add_authy {
     local pam=$4
 
     sed -ie '/authy-openvpn/d' "$server_conf"
-    add_configuration "$server_conf" "plugin $plugin https://api.authy.com/protected/json $key $pam"
+    add_configuration "$server_conf" "plugin $plugin \"https://api.authy.com/protected/json $key $pam\""
 }
 
 function prephase {


### PR DESCRIPTION
Hi,

The PR is a fix for an issue: https://github.com/authy/authy-openvpn/issues/16
Because in OpenVPN 2.4, the --plugin int-string required single- or double-quoted
Therefore, in the post-install script I have added double-quoted for int-string argument. Please consider this PR.

Thanks!